### PR TITLE
Feat: Added hacktoberfest-accepted label to terraform repo

### DIFF
--- a/GitHub/repositories.tf
+++ b/GitHub/repositories.tf
@@ -17,3 +17,10 @@ resource "github_repository" "terraform" {
 
     topics = ["terraform", "iac", "hacktoberfest"]
 }
+
+resource "github_issue_label" "hacktoberfest-accepted" {
+    repository  = github_repository.terraform.id
+    name        = "hacktoberfest-accepted"
+    description = "Hacktoberfest acceptance label"
+    color       = "029F92"
+}


### PR DESCRIPTION
Added hacktoberfest-accepted label to terraform repo

Consider using github_issue_labels instead of github_issue_label